### PR TITLE
Use correct user role_ids for price lookup

### DIFF
--- a/app/controllers/spree/orders_controller_decorator.rb
+++ b/app/controllers/spree/orders_controller_decorator.rb
@@ -16,7 +16,7 @@ Spree::OrdersController.class_eval do
   def option_params_with_roles
     option_params = params[:options] || {}
 
-    role_ids = try_spree_current_user.try(:spree_role_ids)
+    role_ids = try_spree_current_user.try(:price_book_role_ids)
     return option_params.merge({ role_ids: role_ids }) if role_ids.present?
 
     option_params


### PR DESCRIPTION
The spree_role_ids contain all role ids of a user, the price_book_role_ids contain all role ids as well as nil. Therefore price books without role filters will also be searched when looking up prices...